### PR TITLE
Added fuzzy selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349d6b4fabcd9e97e1df1ae15395ac7e49fb144946a0d453959dc2696273b9da"
 dependencies = [
  "console",
+ "fuzzy-matcher",
  "tempfile",
  "zeroize",
 ]
@@ -120,6 +121,15 @@ checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding",
+]
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
 ]
 
 [[package]]
@@ -379,6 +389,15 @@ checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,6 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dialoguer = "0.10.0"
+dialoguer = {version = "0.10.0", features = ["fuzzy-select"]}
 serde = {version = "1.0", features = ["derive"]}
 ureq = {version = "2.4.0", features = ["json"]}

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,5 +1,5 @@
 use crate::license;
-use dialoguer::{console::Style, theme::ColorfulTheme, Input, Select};
+use dialoguer::{console::Style, theme::ColorfulTheme, Input, FuzzySelect};
 use license::LicenseContent;
 use std::{fs, io, process::Command};
 
@@ -40,7 +40,7 @@ pub fn fill_content(license: &LicenseContent) {
 
 // select license
 pub fn select(selections: &Vec<String>) -> String {
-    let selection = Select::with_theme(&ColorfulTheme::default())
+    let selection = FuzzySelect::with_theme(&ColorfulTheme::default())
         .with_prompt("Choose a license")
         .default(0)
         .items(&selections[..])


### PR DESCRIPTION
Fuzzy selection lets users type part of the name of the license to navigate quicker than using the arrow keys.

Resolves #3 