### PR TITLE
fix: crash due to git error

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -33,7 +33,7 @@ pub fn fill_content(license: &LicenseContent) {
             Style::new()
                 .for_stderr()
                 .red()
-                .apply_to("✘ An error occured"),
+                .apply_to("✘ An error occurred"),
             error
         ),
     };

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -92,7 +92,7 @@ fn get_name() -> String {
         }
         None => {
             let input: String = Input::with_theme(&ColorfulTheme::default())
-                .with_prompt("Enter your name")
+                .with_prompt("Name")
                 .interact_text()
                 .unwrap();
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -92,7 +92,7 @@ fn get_name() -> String {
         }
         None => {
             let input: String = Input::with_theme(&ColorfulTheme::default())
-                .with_prompt("Name")
+                .with_prompt("Enter your name")
                 .interact_text()
                 .unwrap();
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -59,7 +59,7 @@ fn get_git_username() -> Option<String> {
         .arg("--get")
         .arg("user.name")
         .output()
-        .expect("fail");
+        .ok()?;
 
     let res: Option<String> = match cmd.status.success() {
         true => Option::from(String::from_utf8_lossy(&cmd.stdout).to_string()),


### PR DESCRIPTION
crashing the program only if git is not working is not seems to a good option, 
earlier, if the command `git config --global --get user.name` does not work the program will crash thanks to `.expect("fail")`.

Now the function will return None if the command does not work. 

```diff
        .arg("user.name")
        .output()
-       .expect("fail");
+       .ok()?;

    let res: Option<String> = match cmd.status.success() {
```

Here `.ok()` will convert the `Result<T, E>` to `Option<T>` and `?` will return `None` from the function if that option is None, i.e if error will happens then the function will return None (which is desired scenario) rather then crashing the program.
