### PR TITLE
 refactor: struct Licenses should just be a type

### DIFF
--- a/src/license.rs
+++ b/src/license.rs
@@ -10,6 +10,8 @@ pub struct License {
     pub node_id: String,
 }
 
+type Licenses = Vec<License>;
+
 #[derive(Debug, Deserialize)]
 pub struct LicenseContent {
     pub key: String,
@@ -23,7 +25,7 @@ pub struct LicenseContent {
 
 impl LicenseContent {
     // fetch license content
-    pub fn fetch_license_content(url: &String) -> LicenseContent {
+    pub fn fetch(url: &String) -> LicenseContent {
         let license: LicenseContent = match ureq::get(&url).call() {
             Ok(res) => res.into_json().unwrap(),
             Err(error) => panic!("Unable to fetch license content: {}", error),
@@ -33,35 +35,26 @@ impl LicenseContent {
     }
 }
 
-#[derive(Debug, Deserialize)]
-pub struct Licenses {
-    pub license: Vec<License>,
+impl From<&String> for LicenseContent {
+    fn from (url: &String) -> LicenseContent {
+        LicenseContent::fetch(&url)
+    }
+
 }
 
-impl Licenses {
+impl From<&License> for LicenseContent {
+    fn from (license: &License) -> LicenseContent {
+        LicenseContent::fetch(&license.url)
+    }
+
+}
+
+impl License {
     // fetch all licenses from github
-    pub fn fetch_licenses() -> Licenses {
-        let body: Vec<License> = match ureq::get("https://api.github.com/licenses").call() {
+    pub fn fetch() -> Licenses {
+        match ureq::get("https://api.github.com/licenses").call() {
             Ok(res) => res.into_json().unwrap(),
             Err(error) => panic!("Unable to fetch licenses: {}", error),
-        };
-
-        Licenses { license: body }
-    }
-
-    pub fn get_license_names(&self) -> Vec<String> {
-        self.license.iter().map(|l| String::from(&l.name)).collect()
-    }
-
-    pub fn get_license_from_name(&self, name: &String) -> LicenseContent {
-        let lic = &self.license;
-
-        let result = lic
-            .into_iter()
-            .filter(|l| l.name == name.clone())
-            .map(|l| l.url.clone())
-            .collect();
-
-        LicenseContent::fetch_license_content(&result)
+        }
     }
 }

--- a/src/license.rs
+++ b/src/license.rs
@@ -26,12 +26,10 @@ pub struct LicenseContent {
 impl LicenseContent {
     // fetch license content
     pub fn fetch(url: &String) -> LicenseContent {
-        let license: LicenseContent = match ureq::get(&url).call() {
+        match ureq::get(&url).call() {
             Ok(res) => res.into_json().unwrap(),
             Err(error) => panic!("Unable to fetch license content: {}", error),
-        };
-
-        license
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,21 @@
 mod helpers;
 mod license;
 
+use license::{License, LicenseContent};
+
 fn main() {
     // fetch licenses
-    let licenses = license::Licenses::fetch_licenses();
+    let licenses = License::fetch();
 
     //  select menu
-    let license = helpers::select(&licenses.get_license_names());
+    let license_name: String = helpers::select(&licenses.iter().map(|l: &License| l.name.clone()).collect());
+
+    // get selected license
+    let selected_license: &License = licenses.iter().find(|l| l.name == license_name).unwrap();
 
     // get license content
-    let license_content = &licenses.get_license_from_name(&license);
+    let license_content = LicenseContent::from(selected_license);
 
     // fill content
-    helpers::fill_content(license_content);
+    helpers::fill_content(&license_content);
 }


### PR DESCRIPTION
- `struct Licenses` should just be wrapped by `type` as in `typedef` in C, and not a whole new struct by itself.
- `get_*` functions from `struct Licenses` should be an easy 1 line refactor, as each function's job was only filtering.
- implement `Licenses::from()` from either `&String` or `&License`.
- rename `fetch_*()` to just `fetch()` alone.